### PR TITLE
Add `members.json`

### DIFF
--- a/members.json
+++ b/members.json
@@ -1,0 +1,183 @@
+{
+  "members": [{
+    "social": [{
+      "type": "keybase",
+      "handle": "lkngtn"
+    }, {
+      "type": "github",
+      "handle": "lkngtn"
+    }],
+    "address": "0x625236038836CecC532664915BD0399647E7826b"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "stellarmagnet"
+    }, {
+      "type": "github",
+      "handle": "stellarmagnet"
+    }],
+    "address": "0xeBAC3108C58Bd4dD48a8110B7750480Cea7bC3Fb"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "jjperezaguinaga"
+    }, {
+      "type": "github",
+      "handle": "jjperezaguinaga"
+    }],
+    "address": "0x016b4De659f33f27e0C9281E41C5EBd6942c6f61"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "bingen"
+    }, {
+      "type": "github",
+      "handle": "bingen"
+    }],
+    "address": "0x6F82dfD56A399390EFe5140d8E0390B200Dbb935"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "imestin"
+    }, {
+      "type": "github",
+      "handle": "imestin"
+    }],
+    "address": "0xF971b59792c8D122602b37E00d310fE069A03619"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "louisgrx"
+    }, {
+      "type": "github",
+      "handle": "louisgr"
+    }],
+    "address": "0xbe40DCADB6bF4De1c7810EcA3504E5f3BEA9cF35"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "maxsemenchuk"
+    }, {
+      "type": "github",
+      "handle": "maxsemenchuk"
+    }],
+    "address": "0xA1c4753Ba0abb8230765660c662CCdE5B801Fb54"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "rperez89"
+    }, {
+      "type": "github",
+      "handle": "rperez89"
+    }],
+    "address": "0x593e1F9809658d0c92e9f092cF01Aad7D0d734f3"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "ro5s"
+    }, {
+      "type": "github",
+      "handle": "ro5s"
+    }],
+    "address": "0x1409f15D77F28882C220860d5F534A1A7a9F3481"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "schmidsi"
+    }, {
+      "type": "github",
+      "handle": "schmidsi"
+    }],
+    "address": "0xe98C357458C89198575a32462760402CaB2A9a4D"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "goliat"
+    }, {
+      "type": "github",
+      "handle": "goliat"
+    }],
+    "address": "0x3E0B02c9f2c5107c2747fCb0E68d997bE2fa0F7f"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "dizzypaty"
+    }, {
+      "type": "github",
+      "handle": "dizzypaty"
+    }],
+    "address": "0xa2e9cbaF5Aef1D1781dE1664f50E50FE3481aab7"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "kevbot"
+    }, {
+      "type": "github",
+      "handle": "kevbot"
+    }],
+    "address": "0xBFc7CAE0Fad9B346270Ae8fde24827D2D779eF0"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "bpierre"
+    }, {
+      "type": "github",
+      "handle": "bpierre"
+    }],
+    "address": "0x50d271519510c55B15408C2C6aeed69800694EF"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "rkzel"
+    }, {
+      "type": "github",
+      "handle": "rkzel"
+    }],
+    "address": "0x66C2211376dF03E34a7E2820125d16b6994c76A"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "mariapg"
+    }, {
+      "type": "github",
+      "handle": "mariapg"
+    }],
+    "address": "0x5fb50ea4af7CE507c4CA5da26dB7a690367137c"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "osarrouy"
+    }, {
+      "type": "github",
+      "handle": "osarrouy"
+    }],
+    "address": "0x8873b045d40A458e46E356a96279aE1820a898b"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "julian_brooks"
+    }, {
+      "type": "github",
+      "handle": "julian_brooks"
+    }],
+    "address": "0x505559E39993cAC587560368BDC04D93c62b35b"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "ottog"
+    }, {
+      "type": "github",
+      "handle": "ottog"
+    }],
+    "address": "0x9819c1f48397eca46e80a7aa549685ca1683b80"
+  }, {
+    "social": [{
+      "type": "keybase",
+      "handle": "giveth"
+    }, {
+      "type": "github",
+      "handle": "giveth"
+    }],
+    "address": "0x839395e20bbB182fa440d08F850E6c7A8f6F078"
+  }]
+}


### PR DESCRIPTION
I am not sure if this is too much maintenance work, but I think it might be worth it to have a machine-readable list of members as well.

The rationale is that this file could be used to programatically grant/revoke access to coop-related things.

The schema is as follows:

**Root**
- `members`: An array of `Member` objects.

**Member**
- `social`: An array of `Social` objects.
- `address`: The Ethereum address associated with this particular member.

**Social**
- `type`: A uniquely identifying string with this social media, e.g. `github` or `keybase`.
- `handle`: The handle of the member on that particular social media site

As a side note, it is also entirely possible to auto-generate the current `README` file from this list. It might also be worth it to include a link to some proofs in the `social` section. I'm not sure on where we should link to, though.